### PR TITLE
FileManager fixes for Windows.

### DIFF
--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -60,7 +60,7 @@ namespace irr {
 }
 
 // For mkdir
-#if !defined(WIN32)
+#if !defined(WIN_BUILD)
 #  include <sys/stat.h>
 #  include <sys/types.h>
 #  include <dirent.h>
@@ -1245,7 +1245,7 @@ void FileManager::checkAndCreateGPDir()
 }   // checkAndCreateGPDir
 
 // ----------------------------------------------------------------------------
-#if !defined(WIN32) && !defined(__APPLE__)
+#if !defined(WIN_BUILD) && !defined(__APPLE__)
 
 /** Find a directory to use for remaining unix variants. Use the new standards
  *  for config directory based on XDG_* environment variables, or a
@@ -1532,7 +1532,7 @@ bool FileManager::removeFile(const std::string &name) const
     if(FileUtils::statU8Path(name, &mystat) < 0) return false;
     if( S_ISREG(mystat.st_mode))
     {
-#if defined(WIN32)
+#if defined(WIN_BUILD)
         return _wremove(StringUtils::utf8ToWide(name).c_str()) == 0;
 #else
         return remove(name.c_str()) == 0;
@@ -1584,7 +1584,7 @@ bool FileManager::removeDirectory(const std::string &name) const
         }
     }
 
-#if defined(WIN32)
+#if defined(WIN_BUILD)
     return RemoveDirectory(StringUtils::utf8ToWide(name).c_str())==TRUE;
 #else
     return remove(name.c_str())==0;
@@ -1659,7 +1659,7 @@ bool FileManager::moveDirectoryInto(std::string source, std::string target)
     if (isDirectory(target))
         return false;
 
-#if defined(WIN32)
+#if defined(WIN_BUILD)
     return MoveFileExW(StringUtils::utf8ToWide(source).c_str(),
         StringUtils::utf8ToWide(target).c_str(),
         MOVEFILE_WRITE_THROUGH) != 0;

--- a/src/io/file_manager.cpp
+++ b/src/io/file_manager.cpp
@@ -49,6 +49,7 @@
 #include <sys/stat.h>
 #include <iostream>
 #include <string>
+#include <filesystem>
 
 #include <IFileSystem.h>
 
@@ -1660,9 +1661,15 @@ bool FileManager::moveDirectoryInto(std::string source, std::string target)
         return false;
 
 #if defined(WIN_BUILD)
-    return MoveFileExW(StringUtils::utf8ToWide(source).c_str(),
-        StringUtils::utf8ToWide(target).c_str(),
-        MOVEFILE_WRITE_THROUGH) != 0;
+    try{
+        std::filesystem::copy(source.c_str(), target.c_str(), std::filesystem::copy_options::recursive);
+        std::filesystem::remove_all(source.c_str());
+        return 1;
+    }
+    catch(std::filesystem::filesystem_error const& ex){
+        Log::error("FileManager", "%s", ex.what());
+        return 0;
+    }
 #else
     return rename(source.c_str(), target.c_str()) != -1;
 #endif


### PR DESCRIPTION
Commit 9d8cecce0 makes file_manager.cpp detect compiling for Windows and compile the correct implementations. This fixes a bug (introduced in the command-manager fork) when updating existing addons using unofficial links on Windows.

Commit f8ed20e2 fixes linked directory issues by replacing ``MoveFileExW`` with ``std::filesystem::copy`` and ``::remove_all`` (notice the ``#include <filesystem>``) to allow the filemanager to follow NTFS Junctions (microsoftese for "hard links"), which are for some reason detected as normal directories by ``std::filesystem::status`` and due to microsoft's incompetence are almost completely impossible to use or resolve with the Win32 API functions at least with normal user privileges.
This fix is C++17 and later only and is thus incompatible with upstream STK 1.x and 2.x.


## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
