### PR TITLE
define WIN32 on windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -909,6 +909,7 @@ if(USE_WIIUSE)
 endif()
 
 if(MSVC OR MINGW)
+  add_definitions(-DWIN32)
   add_definitions(-DWIN_BUILD)
   target_link_libraries(supertuxkart iphlpapi.lib)
   add_custom_command(TARGET supertuxkart POST_BUILD


### PR DESCRIPTION
Improves (not sure / haven't tested if it replaces) what 6c23f94 achieves. It had broken in the first place because the macro ``WIN32`` was deprecated and replaced only with ``_WIN32`` on most compilers. This commit explicitly defines ``WIN32`` in CMakeLists (along with the kimden-defined ``WIN_BUILD``) when compiling with MSVC or MINGW.

This fixes music being broken in the game for me. 9d8cecce0 can also now be reverted lol.

## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
