### PR TITLE
Handle direction markers in ChatManager::handleNormalChatMessage.

### DIFF
--- a/src/utils/chat_manager.cpp
+++ b/src/utils/chat_manager.cpp
@@ -195,9 +195,17 @@ void ChatManager::handleNormalChatMessage(std::shared_ptr<STKPeer> peer,
         return;
     }
 
+    std::string dir_marker = "";
+    if(message.size() > 2){
+        if(message.substr(0,3) == "\u200F")
+            dir_marker = "\u200F";
+        else if(message.substr(0,3) == "\u200E")
+            dir_marker = "\u200E";
+    }
+
     std::string new_prefix = StringUtils::wideToUtf8(
         peer->getMainProfile()->getDecoratedName(decorator)) + ": ";
-    message = new_prefix + message.substr(prefix.length()); 
+    message = dir_marker + new_prefix + message.substr((dir_marker + prefix).length()); 
 
     if (message.size() == 0)
         return;


### PR DESCRIPTION
Fixes malformed RTL messages, a regression introduced in c1ead9e.

[!bug video](https://github.com/user-attachments/assets/19798f92-c620-4163-a528-b029a455016d)

string i typed in the video: ``نومانجو``
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
