### PR TITLE
Prevent error in certain edge cases of ChatManager direction marker handling.

### DIFF
--- a/src/utils/chat_manager.cpp
+++ b/src/utils/chat_manager.cpp
@@ -196,16 +196,19 @@ void ChatManager::handleNormalChatMessage(std::shared_ptr<STKPeer> peer,
     }
 
     std::string dir_marker = "";
-    if(message.size() > 2){
+    if(message.substr(0, prefix.size()) != prefix)
+    {
         if(message.substr(0,3) == "\u200F")
             dir_marker = "\u200F";
         else if(message.substr(0,3) == "\u200E")
             dir_marker = "\u200E";
+        
+        prefix = dir_marker + prefix;
     }
 
     std::string new_prefix = StringUtils::wideToUtf8(
         peer->getMainProfile()->getDecoratedName(decorator)) + ": ";
-    message = dir_marker + new_prefix + message.substr((dir_marker + prefix).length()); 
+    message = dir_marker + new_prefix + message.substr(prefix.length());
 
     if (message.size() == 0)
         return;


### PR DESCRIPTION
## Agreement
```
By creating a pull request in stk-code, you hereby agree to dual-license your contribution as
GNU General Public License version 3 or any later version and
Mozilla Public License version 2 or any later version.

This includes your previous contribution(s) under the same name of contributor.

Keep the above statement in the pull request comment for agreement.

```
